### PR TITLE
Standardize home section heading styles

### DIFF
--- a/components/sections/featured-posts.tsx
+++ b/components/sections/featured-posts.tsx
@@ -35,9 +35,10 @@ export function FeaturedPosts({ posts }: FeaturedPostsProps) {
     <motion.div variants={fadeInUp} className="flex flex-col">
       <div className="flex justify-between items-center mb-5">
         <div className="flex items-center">
-          <h1 className="text-3xl font-extrabold leading-tight tracking-tighter md:text-4xl">
+          <h2 className="text-3xl font-extrabold tracking-tight relative inline-block">
             Featured Posts
-          </h1>
+            <span className="absolute -bottom-1 left-0 w-12 h-1 bg-primary rounded-full" />
+          </h2>
           <div className="ml-3 bg-primary/10 dark:bg-primary/20 rounded-full px-3 py-1 text-xs font-medium text-primary flex items-center">
             <BookOpen className="w-3 h-3 mr-1" />
             Latest insights

--- a/components/sections/github-projects.tsx
+++ b/components/sections/github-projects.tsx
@@ -92,8 +92,10 @@ export function GithubProjects({ repos }: ProjectsListProps) {
     <motion.div variants={fadeInUp} className="space-y-6">
       <div className="flex items-center justify-between">
         <div>
-          <h2 className="text-2xl font-bold tracking-tight">Featured Projects</h2>
-          <div className="h-0.5 w-16 bg-primary/50 rounded-full mt-1"></div>
+          <h2 className="text-3xl font-extrabold tracking-tight relative inline-block">
+            Featured Projects
+            <span className="absolute -bottom-1 left-0 w-12 h-1 bg-primary rounded-full" />
+          </h2>
         </div>
         <Link href="/projects">
           <Button variant="ghost" size="sm" className="gap-1.5">

--- a/components/sections/work-highlights.tsx
+++ b/components/sections/work-highlights.tsx
@@ -24,9 +24,10 @@ export function WorkHighlights() {
   return (
     <motion.div variants={fadeInUp} className="flex flex-col">      <div className="flex justify-between items-center mb-5">
         <div className="flex items-center flex-wrap gap-2">
-          <h1 className="text-3xl font-extrabold leading-tight tracking-tighter md:text-4xl bg-gradient-to-r from-primary-600 to-blue-500 bg-clip-text">
+          <h2 className="text-3xl font-extrabold tracking-tight relative inline-block">
             Work Highlights
-          </h1>
+            <span className="absolute -bottom-1 left-0 w-12 h-1 bg-primary rounded-full" />
+          </h2>
           <div className="bg-primary/10 dark:bg-primary/20 rounded-full px-3 py-1 text-xs font-semibold text-primary dark:text-primary flex items-center shadow-sm">
             <Briefcase className="w-3 h-3 mr-1" />
             Professional experience


### PR DESCRIPTION
All four home-page section headings now use the same pattern:
  h2 · text-3xl font-extrabold tracking-tight · inline primary underline

Changes per file:

featured-posts.tsx
  - h1 → h2 (semantically incorrect for a section heading)
  - Removed leading-tight tracking-tighter md:text-4xl (responsive jump)
  - Added primary underline accent span (matching skills-and-tools style)

work-highlights.tsx
  - h1 → h2
  - Removed gradient text (reserved for the hero name only)
  - Removed leading-tight tracking-tighter md:text-4xl
  - Added primary underline accent span

github-projects.tsx
  - text-2xl font-bold → text-3xl font-extrabold (was visibly smaller)
  - Replaced separate div underline (h-0.5 w-16 opacity-50) with the inline absolute span used by the other sections (h-1 w-12 full opacity)

skills-and-tools.tsx — already correct, no changes needed

https://claude.ai/code/session_01EBJZ5f9GbMmkQyM8uEskuE